### PR TITLE
FreeBSD console driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ The design of the <em>Noted</em> layout was supported by a newly developed <a hr
 ## Layout on Ergonomic Keyboards (crkbd or Cantor)
 ![Noted Layout](/images/crkbd/noted-1-tkl.path.svg)
 
+## Installation
+
+Instructions for Linux/Windows/BSD can be found under the *Installation* section of the <a href="https://dariogoetz.github.io/noted-layout/">introduction page</a>.
+
 ## Troubleshooting
 
 ### The layout file is not working under Debian Bookworm

--- a/docs/index.html
+++ b/docs/index.html
@@ -159,7 +159,7 @@
        <a href="https://github.com/dariogoetz/noted-layout/blob/main/kbd/noted.kbd">noted.kbd.</a>).
        <br>
 
-        As mentioned in the <strong>NOTE</strong>: <em>This driver is  not intended as a complete replacement, however 
+        As mentioned in the <strong>NOTE</strong>: <em>This driver is not intended as a complete replacement, however 
        it will make basic system administration possible using level 1–3 without switching to X.</em>
       </p>
       <p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -150,20 +150,20 @@
 
       <p>
         FreeBSD supports <em>Noted</em> layout whether you are using X or the console (VT or syscons). Using X, 
-        the Linux instructions mostly applies.
+        the Linux instructions mostly apply.
       </p>
       <p>
-        Regarding usage on FreeBSD's console, following is an excerpt from 
+        Regarding usage on FreeBSD's console, the following is an excerpt from 
        <a href="https://www.neo-layout.org/Einrichtung/BSD/">Setup Neo > BSD Systems</a> (be mindful to replace 
        any mentions of neo.kbd with 
-       <a href="https://github.com/Jaso-N7/noted-layout/blob/main/kbd/noted.kbd">noted.kbd.</a>).
+       <a href="https://github.com/dariogoetz/noted-layout/blob/main/kbd/noted.kbd">noted.kbd.</a>).
        <br>
 
         As mentioned in the <strong>NOTE</strong>: <em>This driver is  not intended as a complete replacement, however 
        it will make basic system administration possible using level 1–3 without switching to X.</em>
       </p>
       <p>
-        For FreeBSD on the console, the <a href="https://github.com/Jaso-N7/noted-layout/blob/main/kbd/noted.kbd">noted.kbd</a> 
+        For FreeBSD on the console, the <a href="https://github.com/dariogoetz/noted-layout/blob/main/kbd/noted.kbd">noted.kbd</a> 
         driver file must be loaded with the following commands:
             <ol>
 	          <li><pre>$ kbdcontrol -l noted</pre></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -148,6 +148,36 @@
         There exist no drivers for MacOS, currently.
       </p>
 
+      <p>
+        FreeBSD supports <em>Noted</em> layout whether you are using X or the console (VT or syscons). Using X, 
+        the Linux instructions mostly applies.
+      </p>
+      <p>
+        Regarding usage on FreeBSD's console, following is an excerpt from 
+       <a href="https://www.neo-layout.org/Einrichtung/BSD/">Setup Neo > BSD Systems</a> (be mindful to replace 
+       any mentions of neo.kbd with 
+       <a href="https://github.com/Jaso-N7/noted-layout/blob/main/kbd/noted.kbd">noted.kbd.</a>).
+       <br>
+
+        As mentioned in the <strong>NOTE</strong>: <em>This driver is  not intended as a complete replacement, however 
+       it will make basic system administration possible using level 1–3 without switching to X.</em>
+      </p>
+      <p>
+        For FreeBSD on the console, the <a href="https://github.com/Jaso-N7/noted-layout/blob/main/kbd/noted.kbd">noted.kbd</a> 
+        driver file must be loaded with the following commands:
+            <ol>
+	          <li><pre>$ kbdcontrol -l noted</pre></li>
+                  <li>To use the layout permanently, as a root user, copy (or move) the file to the registry for keymaps:
+                        <ul>
+                              <li>For VT: <pre># cp noted.kbd /usr/share/vt/keymaps/</pre></li>
+                              <li>Or below Syscons: <pre># cp noted.kbd /usr/share/syscons/keymaps/</pre></li>
+                        </ul>
+                   </li>
+                  <li>Then <pre>sysrc keymap="noted"</pre></li>
+            </ol>
+
+      </p>
+
       </p>
     </section>
 

--- a/kbd/noted.kbd
+++ b/kbd/noted.kbd
@@ -1,6 +1,6 @@
 # $FreeBSD: src/share/syscons/keymaps/german.iso.acc.kbd,v 1.1 2003/06/19 08:34:38 murray Exp $
 #
-# Noted Layout (v0.1.1) based on neo.kbd (v0.1)
+# Noted Layout (v0.1.3) based on neo.kbd (v0.1)
 #
 #                                                         alt
 # scan                       cntrl          alt    alt   cntrl lock
@@ -32,7 +32,7 @@
   023   'm'    'M'    bel    bel    '>'    '>'    bel    bel     C
   024   'l'    'L'    ack    ack    '='    '='    ack    ack     C
   025   'f'    'F'    dc1    dc1    '&'    '&'    nul    nul     C
-  026   'j'    'J'    nop    nop    252    220    esc    nop     C
+  026   'j'    'J'    nop    nop    '@'    '@'    esc    nop     C
   027   223    nop    nop    nop    252    220    esc    nop     C
 # Use this line for second row after NOTED's M3
 #   027   dtil   '*'    nop    nop    duml   duml  nop    nop     O

--- a/kbd/noted.kbd
+++ b/kbd/noted.kbd
@@ -1,6 +1,6 @@
 # $FreeBSD: src/share/syscons/keymaps/german.iso.acc.kbd,v 1.1 2003/06/19 08:34:38 murray Exp $
 #
-# Noted Layout (v0.1.3) based on neo.kbd (v0.1)
+# Noted Layout (v0.2.0) based on neo.kbd (v0.1)
 #
 #                                                         alt
 # scan                       cntrl          alt    alt   cntrl lock
@@ -34,21 +34,20 @@
   025   'f'    'F'    dc1    dc1    '&'    '&'    nul    nul     C
   026   'j'    'J'    nop    nop    '@'    '@'    esc    nop     C
   027   223    nop    nop    nop    252    220    esc    nop     C
-# Use this line for second row after NOTED's M3
-#   027   dtil   '*'    nop    nop    duml   duml  nop    nop     O
   028   cr     cr     nl     nl     cr     cr     nl     nl      O
   029   lctrl  lctrl  lctrl  lctrl  lctrl  lctrl  lctrl  lctrl   O
-  030   'u'    'U'    nak    nak    '\'    '\'    nak    nak     C
-  031   'i'    'I'    ht     ht     '/'    '/'    ht     ht      C
-  032   'a'    'A'    soh    soh    '{'    '{'    soh    soh     C
+  030   'c'    'U'    nak    nak    '\'    '\'    nak    nak     C
+  031   's'    'I'    ht     ht     '/'    '/'    ht     ht      C
+  032   'i'    'A'    soh    soh    '{'    '{'    soh    soh     C
   033   'e'    'E'    enq    enq    '}'    '}'    enq    enq     C
   034   'o'    'O'    si     si    '*'    '*'     si     si      C
-  035   's'    'S'    dc3    dc3    '?'    '?'    dc3    dc3     C
-  036   'n'    'N'    so     so     '('    '('    so     so      C
-  037   'r'    'R'    dc2    dc2    ')'    ')'    vt     vt      C
-  038   't'    'T'    dc4    dc4    '-'    '-'    dc2    dc2     C
-  039   'd'    'D'    eot    eot    ':'    ':'    eot    eot     C
-  040   'y'    'Y'    em     em     '@'    '@'    nop    nop     C
+  035   'd'    'S'    dc3    dc3    '?'    '?'    dc3    dc3     C
+  036   't'    'N'    so     so     '('    '('    so     so      C
+  037   'n'    'R'    dc2    dc2    ')'    ')'    vt     vt      C
+  038   'r'    'T'    dc4    dc4    '-'    '-'    dc2    dc2     C
+  039   'h'    'D'    eot    eot    ':'    ':'    eot    eot     C
+  040   dtil   '*'    nop    nop    duml   duml   nop    nop     O
+  # 040       'Y'    em     em     '@'    '@'    nop    nop     C
   041   dcir   176    rs     rs     '^'    176    em     em      O
   042   lshift lshift lshift lshift lshift lshift lshift lshift  O
   043   ralt   ralt   ralt   ralt   ralt   ralt   ralt   ralt    O

--- a/kbd/noted.kbd
+++ b/kbd/noted.kbd
@@ -1,0 +1,144 @@
+# $FreeBSD: src/share/syscons/keymaps/german.iso.acc.kbd,v 1.1 2003/06/19 08:34:38 murray Exp $
+#
+# Noted Layout (v0.1.0) based on neo.kbd (v0.1)
+#
+#                                                         alt
+# scan                       cntrl          alt    alt   cntrl lock
+# code  base   shift  cntrl  shift  alt    shift  cntrl  shift state
+# ------------------------------------------------------------------
+  000   nop    nop    nop    nop    nop    nop    nop    nop     O
+  001   esc    esc    esc    esc    esc    esc    debug  esc     O
+  002   '1'    '!'    nop    nop    '1'    '!'    nop    nop     O
+  003   '2'    '"'    nop    nop    178    178    nop    nop     O
+  004   '3'    167    nop    nop    179    179    nop    nop     O
+  005   '4'    171    nop    nop    '4'    '$'    nop    nop     O
+  006   '5'    187    nop    nop    '5'    '%'    nop    nop     O
+  007   '6'    164    nop    nop    164    '&'    nop    nop     O
+  008   '7'    '$'    nop    nop    '{'    '{'    nop    nop     O
+  009   '8'    '"'    esc    esc    '['    '['    esc    esc     O
+  010   '9'    '"'    gs     gs     ']'    ']'    gs     gs      O
+  011   '0'    '"'    nop    nop    '}'    '}'    nop    nop     O
+  012   '-'    '-'    fs     fs     nop    nop    fs     fs      O
+  013   dacu   dgra   nop    nop    179    180    nop    nop     O
+  014   bs     bs     del    del    bs     bs     del    del     O
+  015   ht     btab   nop    nop    ht     btab   nop    nop     O
+  016   'z'    'X'    can    can    '@'    '@'    can    can     C
+  017   'y'    'V'    syn    syn    '_'    '_'    syn    syn     C
+  018   'u'    'L'    ff     ff     '['    '['    ff     ff      C
+  019   'a'    'C'    etx    etx    ']'    ']'    etx    etx     C
+  020   'q'    'W'    etb    etb    '^'    '^'    etb    etb     C
+  021   'p'    'K'    vt     vt     '!'    '!'    vt     vt      C
+  022   'b'    'H'    bs     bs     '<'    '<'    bs     bs      C
+  023   'm'    'G'    bel    bel    '>'    '>'    bel    bel     C
+  024   'l'    'F'    ack    ack    '='    '='    ack    ack     C
+  025   'f'    'Q'    dc1    dc1    '&'    '&'    nul    nul     C
+  026   'j'    nop    nop    nop    252    220    esc    nop     C
+  027   223    nop    nop    nop    252    220    esc    nop     C
+# Use this line for second row after NOTED's M3
+#   027   dtil   '*'    nop    nop    duml   duml  nop    nop     O
+  028   cr     cr     nl     nl     cr     cr     nl     nl      O
+  029   lctrl  lctrl  lctrl  lctrl  lctrl  lctrl  lctrl  lctrl   O
+  030   'u'    'U'    nak    nak    '\'    '\'    nak    nak     C
+  031   'i'    'I'    ht     ht     '/'    '/'    ht     ht      C
+  032   'a'    'A'    soh    soh    '{'    '{'    soh    soh     C
+  033   'e'    'E'    enq    enq    '}'    '}'    enq    enq     C
+  034   'o'    'O'    si     si    '*'    '*'     si     si      C
+  035   's'    'S'    dc3    dc3    '?'    '?'    dc3    dc3     C
+  036   'n'    'N'    so     so     '('    '('    so     so      C
+  037   'r'    'R'    dc2    dc2    ')'    ')'    vt     vt      C
+  038   't'    'T'    dc4    dc4    '-'    '-'    dc2    dc2     C
+  039   'd'    'D'    eot    eot    ':'    ':'    eot    eot     C
+  040   'y'    'Y'    em     em     '@'    '@'    nop    nop     C
+  041   dcir   176    rs     rs     '^'    176    em     em      O
+  042   lshift lshift lshift lshift lshift lshift lshift lshift  O
+  043   ralt   ralt   ralt   ralt   ralt   ralt   ralt   ralt    O
+  044   252    220    nop    nop    '#'    '#'    nop    nop     C
+  045   246    214    nop    nop    '$'    '$'    nop    nop     C
+  046   228    196    etx    etx    '|'    '|'    etx    etx     C
+  047   'p'    'P'    dle    dle    '~'    '~'    dle    dle     C
+  048   'z'    'Z'    sub    sub    '`'    '`'    sub    sub     C
+  049   'b'    'B'    stx    stx    '+'    '+'    stx    stx     C
+  050   'm'    'M'    cr     cr     '%'    '%'    cr     cr      C
+  051   ','    ';'    nop    nop    '"'    '"'    nop    nop     O
+  052   '.'    ':'    nop    nop    '''    '''    nop    nop     O
+  053   'j'    'J'    nl     nl     ';'    ';'    nl     nl      O
+  054   rshift rshift rshift rshift rshift rshift rshift rshift  O
+  055   '*'    '*'    '*'    '*'    '*'    '*'    '*'    '*'     O
+  056   lalt   lalt   lalt   lalt   lalt   lalt   lalt   lalt    O
+  057   ' '    ' '    nul    ' '    ' '    ' '    susp   ' '     O
+  058   ralt   ralt   ralt   ralt   ralt   ralt   ralt   ralt    O
+  059   fkey01 fkey13 fkey25 fkey37 scr01  scr11  scr01  scr11   O
+  060   fkey02 fkey14 fkey26 fkey38 scr02  scr12  scr02  scr12   O
+  061   fkey03 fkey15 fkey27 fkey39 scr03  scr13  scr03  scr13   O
+  062   fkey04 fkey16 fkey28 fkey40 scr04  scr14  scr04  scr14   O
+  063   fkey05 fkey17 fkey29 fkey41 scr05  scr15  scr05  scr15   O
+  064   fkey06 fkey18 fkey30 fkey42 scr06  scr16  scr06  scr16   O
+  065   fkey07 fkey19 fkey31 fkey43 scr07  scr07  scr07  scr07   O
+  066   fkey08 fkey20 fkey32 fkey44 scr08  scr08  scr08  scr08   O
+  067   fkey09 fkey21 fkey33 fkey45 scr09  scr09  scr09  scr09   O
+  068   fkey10 fkey22 fkey34 fkey46 scr10  scr10  scr10  scr10   O
+  069   nlock  nlock  nlock  nlock  nlock  nlock  nlock  nlock   O
+  070   slock  slock  slock  slock  slock  slock  slock  slock   O
+  071   fkey49 '7'    '7'    '7'    '7'    '7'    '7'    '7'     N
+  072   fkey50 '8'    '8'    '8'    '8'    '8'    '8'    '8'     N
+  073   fkey51 '9'    '9'    '9'    '9'    '9'    '9'    '9'     N
+  074   fkey52 '-'    '-'    '-'    '-'    '-'    '-'    '-'     N
+  075   fkey53 '4'    '4'    '4'    '4'    '4'    '4'    '4'     N
+  076   fkey54 '5'    '5'    '5'    '5'    '5'    '5'    '5'     N
+  077   fkey55 '6'    '6'    '6'    '6'    '6'    '6'    '6'     N
+  078   fkey56 '+'    '+'    '+'    '+'    '+'    '+'    '+'     N
+  079   fkey57 '1'    '1'    '1'    '1'    '1'    '1'    '1'     N
+  080   fkey58 '2'    '2'    '2'    '2'    '2'    '2'    '2'     N
+  081   fkey59 '3'    '3'    '3'    '3'    '3'    '3'    '3'     N
+  082   fkey60 '0'    '0'    '0'    '0'    '0'    '0'    '0'     N
+  083   del    '.'    '.'    '.'    '.'    '.'    boot   boot    N
+  084   nop    nop    nop    nop    nop    nop    nop    nop     O
+  085   nop    nop    nop    nop    nop    nop    nop    nop     O
+  086   '<'    '>'    nop    nop    '|'    166    nop    nop     O
+  087   fkey11 fkey23 fkey35 fkey47 scr11  scr11  scr11  scr11   O
+  088   fkey12 fkey24 fkey36 fkey48 scr12  scr12  scr12  scr12   O
+  089   cr     cr     nl     nl     cr     cr     nl     nl      O
+  090   rctrl  rctrl  rctrl  rctrl  rctrl  rctrl  rctrl  rctrl   O
+  091   '/'    '/'    '/'    '/'    '/'    '/'    '/'    '/'     N
+  092   nscr   pscr   debug  debug  nop    nop    nop    nop     O
+  093   ralt   ralt   ralt   ralt   ralt   ralt   ralt   ralt    O
+  094   fkey49 fkey49 fkey49 fkey49 fkey49 fkey49 fkey49 fkey49  O
+  095   fkey50 fkey50 fkey50 fkey50 fkey50 fkey50 fkey50 fkey50  O
+  096   fkey51 fkey51 fkey51 fkey51 fkey51 fkey51 fkey51 fkey51  O
+  097   fkey53 fkey53 fkey53 fkey53 fkey53 fkey53 fkey53 fkey53  O
+  098   fkey55 fkey55 fkey55 fkey55 fkey55 fkey55 fkey55 fkey55  O
+  099   fkey57 fkey57 fkey57 fkey57 fkey57 fkey57 fkey57 fkey57  O
+  100   fkey58 fkey58 fkey58 fkey58 fkey58 fkey58 fkey58 fkey58  O
+  101   fkey59 fkey59 fkey59 fkey59 fkey59 fkey59 fkey59 fkey59  O
+  102   fkey60 paste  fkey60 fkey60 fkey60 fkey60 fkey60 fkey60  O
+  103	fkey61 fkey61 fkey61 fkey61 fkey61 fkey61 boot   fkey61  O
+  104   slock  saver  slock  saver  susp   nop    susp   nop     O
+  105   fkey62 fkey62 fkey62 fkey62 fkey62 fkey62 fkey62 fkey62  O
+  106   fkey63 fkey63 fkey63 fkey63 fkey63 fkey63 fkey63 fkey63  O
+  107   fkey64 fkey64 fkey64 fkey64 fkey64 fkey64 fkey64 fkey64  O
+  108   nop    nop    nop    nop    nop    nop    nop    nop     O
+
+  dgra  '`'  ( 'a' 224 ) ( 'A' 192 ) ( 'e' 232 ) ( 'E' 200 ) 
+             ( 'i' 236 ) ( 'I' 204 ) ( 'o' 242 ) ( 'O' 210 ) 
+             ( 'u' 249 ) ( 'U' 217 )
+  dacu  180  ( 'a' 225 ) ( 'A' 193 ) ( 'e' 233 ) ( 'E' 201 ) 
+             ( 'i' 237 ) ( 'I' 205 ) ( 'o' 243 ) ( 'O' 211 ) 
+             ( 'u' 250 ) ( 'U' 218 ) ( 'y' 253 ) ( 'Y' 221 ) 
+  dcir  '^'  ( 'a' 226 ) ( 'A' 194 ) ( 'e' 234 ) ( 'E' 202 ) 
+             ( 'i' 238 ) ( 'I' 206 ) ( 'o' 244 ) ( 'O' 212 ) 
+             ( 'u' 251 ) ( 'U' 219 )
+  dtil  '~'  ( 'a' 227 ) ( 'A' 195 ) ( 'n' 241 ) ( 'N' 209 ) 
+             ( 'o' 245 ) ( 'O' 213 )
+  dmac  000
+  dbre  000
+  ddot  000
+  duml  168  ( 'a' 228 ) ( 'A' 196 ) ( 'e' 235 ) ( 'E' 203 ) 
+             ( 'i' 239 ) ( 'I' 207 ) ( 'o' 246 ) ( 'O' 214 ) 
+             ( 'u' 252 ) ( 'U' 220 ) ( 'y' 255 )
+  dsla  000
+  drin  176  ( 'a' 229 ) ( 'A' 197 )
+  dced  184  ( 'c' 231 ) ( 'C' 199 )
+  dapo  000
+  ddac  000
+  dogo  000
+  dcar  000

--- a/kbd/noted.kbd
+++ b/kbd/noted.kbd
@@ -1,6 +1,6 @@
 # $FreeBSD: src/share/syscons/keymaps/german.iso.acc.kbd,v 1.1 2003/06/19 08:34:38 murray Exp $
 #
-# Noted Layout (v0.1.0) based on neo.kbd (v0.1)
+# Noted Layout (v0.1.1) based on neo.kbd (v0.1)
 #
 #                                                         alt
 # scan                       cntrl          alt    alt   cntrl lock
@@ -22,17 +22,17 @@
   013   dacu   dgra   nop    nop    179    180    nop    nop     O
   014   bs     bs     del    del    bs     bs     del    del     O
   015   ht     btab   nop    nop    ht     btab   nop    nop     O
-  016   'z'    'X'    can    can    '@'    '@'    can    can     C
-  017   'y'    'V'    syn    syn    '_'    '_'    syn    syn     C
-  018   'u'    'L'    ff     ff     '['    '['    ff     ff      C
-  019   'a'    'C'    etx    etx    ']'    ']'    etx    etx     C
-  020   'q'    'W'    etb    etb    '^'    '^'    etb    etb     C
-  021   'p'    'K'    vt     vt     '!'    '!'    vt     vt      C
-  022   'b'    'H'    bs     bs     '<'    '<'    bs     bs      C
-  023   'm'    'G'    bel    bel    '>'    '>'    bel    bel     C
-  024   'l'    'F'    ack    ack    '='    '='    ack    ack     C
-  025   'f'    'Q'    dc1    dc1    '&'    '&'    nul    nul     C
-  026   'j'    nop    nop    nop    252    220    esc    nop     C
+  016   'z'    'Z'    can    can    '@'    '@'    can    can     C
+  017   'y'    'Y'    syn    syn    '_'    '_'    syn    syn     C
+  018   'u'    'U'    ff     ff     '['    '['    ff     ff      C
+  019   'a'    'A'    etx    etx    ']'    ']'    etx    etx     C
+  020   'q'    'Q'    etb    etb    '^'    '^'    etb    etb     C
+  021   'p'    'P'    vt     vt     '!'    '!'    vt     vt      C
+  022   'b'    'B'    bs     bs     '<'    '<'    bs     bs      C
+  023   'm'    'M'    bel    bel    '>'    '>'    bel    bel     C
+  024   'l'    'L'    ack    ack    '='    '='    ack    ack     C
+  025   'f'    'F'    dc1    dc1    '&'    '&'    nul    nul     C
+  026   'j'    'J'    nop    nop    252    220    esc    nop     C
   027   223    nop    nop    nop    252    220    esc    nop     C
 # Use this line for second row after NOTED's M3
 #   027   dtil   '*'    nop    nop    duml   duml  nop    nop     O

--- a/kbd/noted.kbd
+++ b/kbd/noted.kbd
@@ -1,6 +1,6 @@
 # $FreeBSD: src/share/syscons/keymaps/german.iso.acc.kbd,v 1.1 2003/06/19 08:34:38 murray Exp $
 #
-# Noted Layout (v0.2.2) based on neo.kbd (v0.1)
+# Noted Layout (v0.3.1) based on neo.kbd (v0.1)
 #
 #                                                         alt
 # scan                       cntrl          alt    alt   cntrl lock
@@ -47,20 +47,22 @@
   038   'r'    'R'    dc4    dc4    '-'    '-'    dc2    dc2     C
   039   'h'    'H'    eot    eot    ':'    ':'    eot    eot     C
   040   dtil   '*'    nop    nop    duml   duml   nop    nop     O
-  # 040       'Y'    em     em     '@'    '@'    nop    nop     C
   041   dcir   176    rs     rs     '^'    176    em     em      O
   042   lshift lshift lshift lshift lshift lshift lshift lshift  O
   043   ralt   ralt   ralt   ralt   ralt   ralt   ralt   ralt    O
-  044   252    220    nop    nop    '#'    '#'    nop    nop     C
-  045   246    214    nop    nop    '$'    '$'    nop    nop     C
-  046   228    196    etx    etx    '|'    '|'    etx    etx     C
-  047   'p'    'P'    dle    dle    '~'    '~'    dle    dle     C
-  048   'z'    'Z'    sub    sub    '`'    '`'    sub    sub     C
-  049   'b'    'B'    stx    stx    '+'    '+'    stx    stx     C
-  050   'm'    'M'    cr     cr     '%'    '%'    cr     cr      C
+  044   'v'    'V'    nop    nop    '#'    '#'    nop    nop     C
+  045   'x'    'X'    nop    nop    '$'    '$'    nop    nop     C
+  046   252    220    etx    etx    '|'    '|'    etx    etx     C
+  # 044   252    220    nop    nop    '#'    '#'    nop    nop     C
+  # 045   246    214    nop    nop    '$'    '$'    nop    nop     C
+  # 046   228    196    etx    etx    '|'    '|'    etx    etx     C
+  047   228    196    dle    dle    '~'    '~'    dle    dle     C
+  048   246    214    sub    sub    '`'    '`'    sub    sub     C
+  049   'w'    'W'    stx    stx    '+'    '+'    stx    stx     C
+  050   'g'    'G'    cr     cr     '%'    '%'    cr     cr      C
   051   ','    ';'    nop    nop    '"'    '"'    nop    nop     O
   052   '.'    ':'    nop    nop    '''    '''    nop    nop     O
-  053   'j'    'J'    nl     nl     ';'    ';'    nl     nl      O
+  053   'k'    'K'    nl     nl     ';'    ';'    nl     nl      O
   054   rshift rshift rshift rshift rshift rshift rshift rshift  O
   055   '*'    '*'    '*'    '*'    '*'    '*'    '*'    '*'     O
   056   lalt   lalt   lalt   lalt   lalt   lalt   lalt   lalt    O

--- a/kbd/noted.kbd
+++ b/kbd/noted.kbd
@@ -1,6 +1,6 @@
 # $FreeBSD: src/share/syscons/keymaps/german.iso.acc.kbd,v 1.1 2003/06/19 08:34:38 murray Exp $
 #
-# Noted Layout (v0.2.0) based on neo.kbd (v0.1)
+# Noted Layout (v0.2.2) based on neo.kbd (v0.1)
 #
 #                                                         alt
 # scan                       cntrl          alt    alt   cntrl lock
@@ -36,16 +36,16 @@
   027   223    nop    nop    nop    252    220    esc    nop     C
   028   cr     cr     nl     nl     cr     cr     nl     nl      O
   029   lctrl  lctrl  lctrl  lctrl  lctrl  lctrl  lctrl  lctrl   O
-  030   'c'    'U'    nak    nak    '\'    '\'    nak    nak     C
-  031   's'    'I'    ht     ht     '/'    '/'    ht     ht      C
-  032   'i'    'A'    soh    soh    '{'    '{'    soh    soh     C
+  030   'c'    'C'    nak    nak    '\'    '\'    nak    nak     C
+  031   's'    'S'    ht     ht     '/'    '/'    ht     ht      C
+  032   'i'    'I'    soh    soh    '{'    '{'    soh    soh     C
   033   'e'    'E'    enq    enq    '}'    '}'    enq    enq     C
   034   'o'    'O'    si     si    '*'    '*'     si     si      C
-  035   'd'    'S'    dc3    dc3    '?'    '?'    dc3    dc3     C
-  036   't'    'N'    so     so     '('    '('    so     so      C
-  037   'n'    'R'    dc2    dc2    ')'    ')'    vt     vt      C
-  038   'r'    'T'    dc4    dc4    '-'    '-'    dc2    dc2     C
-  039   'h'    'D'    eot    eot    ':'    ':'    eot    eot     C
+  035   'd'    'D'    dc3    dc3    '?'    '?'    dc3    dc3     C
+  036   't'    'T'    so     so     '('    '('    so     so      C
+  037   'n'    'N'    dc2    dc2    ')'    ')'    vt     vt      C
+  038   'r'    'R'    dc4    dc4    '-'    '-'    dc2    dc2     C
+  039   'h'    'H'    eot    eot    ':'    ':'    eot    eot     C
   040   dtil   '*'    nop    nop    duml   duml   nop    nop     O
   # 040       'Y'    em     em     '@'    '@'    nop    nop     C
   041   dcir   176    rs     rs     '^'    176    em     em      O


### PR DESCRIPTION
Greetings and Thanks Mr. Dario Götz,

I am a big fan of the noted layout and use it extensively on Windows, Linux and FreeBSD (Xorg). There are times when I don't need to use X on FreeBSD, and using QWERTY on console slows me down. With that in mind, I created this driver based on the neo version. Unfortunately, I am not too familiar with Linux's map layout, hence the choice.

Please review, feel free suggest/make any necessary adjustments.

Do not hesitate to reach out with any feedback / recommendations / questions.

Best regards,
Jason Robinson